### PR TITLE
Fix omniauth workflow

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,14 @@
 class SessionsController < ApplicationController
+
+  def request_omniauth
+    auth_params = {
+      :state => params[:org_uid]
+    }
+    auth_params = URI.escape(auth_params.collect{|k,v| "#{k}=#{v}"}.join('&'))
+
+    redirect_to "/auth/#{params[:provider]}?#{auth_params}", id: "sign_in"
+  end
+
   # Link an Organization to SalesForce OAuth account
   def create_omniauth
     Organization.from_omniauth(params[:state], env["omniauth.auth"])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < ApplicationController
   # Link an Organization to SalesForce OAuth account
   def create_omniauth
-    Organization.from_omniauth(env["omniauth.auth"])
+    Organization.from_omniauth(params[:state], env["omniauth.auth"])
     redirect_to root_url
   end
 
@@ -14,7 +14,7 @@ class SessionsController < ApplicationController
       organization.refresh_token = nil
       organization.save
     end
-    
+
     redirect_to root_url
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -6,34 +6,36 @@ class Organization < ActiveRecord::Base
     #group.free_trial_end_at = maestrano.free_trial_end_at
     #group.some_required_field = 'some-appropriate-default-value'
   end
-  
+
   #===================================
   # Associations
   #===================================
   has_many :user_organization_rels
   has_many :users, through: :user_organization_rels
-  
+
   #===================================
   # Validation
   #===================================
   validates :name, presence: true
-  
+
   def add_member(user)
     unless self.member?(user)
       self.user_organization_rels.create(user:user)
     end
   end
-  
+
   def member?(user)
     self.user_organization_rels.where(user_id:user.id).count > 0
   end
-  
+
   def remove_member(user)
     self.user_organization_rels.where(user_id:user.id).delete_all
   end
 
-  def self.from_omniauth(auth)
-    where(auth.slice(:provider, :uid).permit!).first_or_initialize.tap do |organization|
+  def self.from_omniauth(uid, auth)
+    organization = Organisation.find_by_uid(orga_uid)
+    if organization
+    # where(auth.slice(:provider, :uid).permit!).first_or_initialize.tap do |organization|
       organization.oauth_provider = auth.provider
       organization.oauth_uid = auth.uid
       organization.oauth_token = auth.credentials.token

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -33,7 +33,7 @@ class Organization < ActiveRecord::Base
   end
 
   def self.from_omniauth(uid, auth)
-    organization = Organisation.find_by_uid(orga_uid)
+    organization = Organization.find_by_uid(uid)
     if organization
     # where(auth.slice(:provider, :uid).permit!).first_or_initialize.tap do |organization|
       organization.oauth_provider = auth.provider

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -28,20 +28,20 @@ class Organization < ActiveRecord::Base
     self.user_organization_rels.where(user_id:user.id).count > 0
   end
 
+  def admin?(user)
+    self.member?(user) #TODO
+  end
+
   def remove_member(user)
     self.user_organization_rels.where(user_id:user.id).delete_all
   end
 
-  def self.from_omniauth(uid, auth)
-    organization = Organization.find_by_uid(uid)
-    if organization
-    # where(auth.slice(:provider, :uid).permit!).first_or_initialize.tap do |organization|
-      organization.oauth_provider = auth.provider
-      organization.oauth_uid = auth.uid
-      organization.oauth_token = auth.credentials.token
-      organization.refresh_token = auth.credentials.refresh_token
-      organization.instance_url = auth.credentials.instance_url
-      organization.save!
-    end
+  def from_omniauth(auth)
+    organization.oauth_provider = auth.provider
+    organization.oauth_uid = auth.uid
+    organization.oauth_token = auth.credentials.token
+    organization.refresh_token = auth.credentials.refresh_token
+    organization.instance_url = auth.credentials.instance_url
+    organization.save!
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -37,11 +37,11 @@ class Organization < ActiveRecord::Base
   end
 
   def from_omniauth(auth)
-    organization.oauth_provider = auth.provider
-    organization.oauth_uid = auth.uid
-    organization.oauth_token = auth.credentials.token
-    organization.refresh_token = auth.credentials.refresh_token
-    organization.instance_url = auth.credentials.instance_url
-    organization.save!
+    self.oauth_provider = auth.provider
+    self.oauth_uid = auth.uid
+    self.oauth_token = auth.credentials.token
+    self.refresh_token = auth.credentials.refresh_token
+    self.instance_url = auth.credentials.instance_url
+    self.save!
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ActiveRecord::Base
   #===================================
   validates :email, presence: true
 
-  def can_link(org_uid)
+  def can_omniauth(org_uid)
     self.organizations.exists?(uid: org_uid) #TODO check admin/super-admin
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,8 @@ class User < ActiveRecord::Base
   # Validation
   #===================================
   validates :email, presence: true
+
+  def can_link(org_uid)
+    self.organizations.exists?(uid: org_uid) #TODO check admin/super-admin
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,8 +19,4 @@ class User < ActiveRecord::Base
   # Validation
   #===================================
   validates :email, presence: true
-
-  def can_omniauth(org_uid)
-    self.organizations.exists?(uid: org_uid) #TODO check admin/super-admin
-  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
 </head>
 <body>
 
-  <p>Data sharing between Connec!™ and SalesForce APIs (v0.1)</p>
+  <p>Data sharing between Connec!™ and SalesForce APIs (v0.2)</p>
   <%= link_to "Synchronize all organizations", home_synchronize_path, method: :post %> <br/>
 
   <div id="current-user-status">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
           Linked to SalesForce Account <%= organization.oauth_uid %> <br/>
           <%= link_to "Disconnect #{organization.uid} from your Salesforce account", signout_omniauth_path(organization_id: organization.id) %>
         <% else %>
-          <%= link_to "Link #{organization.uid} to your Salesforce account", "/auth/salesforce?state=#{organization.uid}", id: "sign_in" %>
+          <%= link_to "Link #{organization.uid} to your Salesforce account", "/auth/salesforce/request?org_uid=#{organization.uid}" %>
         <% end %>
       <% end %>
     <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
 </head>
 <body>
 
-  <p>Data sharing between Connec!™ and SalesForce APIs</p>
+  <p>Data sharing between Connec!™ and SalesForce APIs (v0.1)</p>
   <%= link_to "Synchronize all organizations", home_synchronize_path, method: :post %> <br/>
 
   <div id="current-user-status">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
-  
+
   <p>Data sharing between Connec!™ and SalesForce APIs</p>
   <%= link_to "Synchronize all organizations", home_synchronize_path, method: :post %> <br/>
 
@@ -22,7 +22,7 @@
           Linked to SalesForce Account <%= organization.oauth_uid %> <br/>
           <%= link_to "Disconnect #{organization.uid} from your Salesforce account", signout_omniauth_path(organization_id: organization.id) %>
         <% else %>
-          <%= link_to "Link #{organization.uid} to your Salesforce account", "/auth/salesforce", id: "sign_in" %>
+          <%= link_to "Link #{organization.uid} to your Salesforce account", "/auth/salesforce?state=#{organization.uid}", id: "sign_in" %>
         <% end %>
       <% end %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get 'home/index' => 'home#index'
   post 'home/synchronize' => 'home#synchronize'
 
+  match 'auth/:provider/request', to: 'sessions#request_omniauth', via: [:get, :post]
   match 'auth/:provider/callback', to: 'sessions#create_omniauth', via: [:get, :post]
   match 'auth/failure', to: redirect('/'), via: [:get, :post]
   match 'signout_omniauth', to: 'sessions#destroy_omniauth', as: 'signout_omniauth', via: [:get, :post]


### PR DESCRIPTION
Uses omniauth state parameter to keep track of the organization uid.

Add check for create and destroying omniauth (wip)
