### PR TITLE
Remove AnnualRevenue field from account/organization mapper

### DIFF
--- a/app/models/entities/organization.rb
+++ b/app/models/entities/organization.rb
@@ -36,7 +36,6 @@ class OrganizationMapper
 
   map from('name'),  to('Name')
   map from('industry'),  to('Industry')
-  map from('annual_revenue'), to('AnnualRevenue')
   map from('number_of_employees'), to('NumberOfEmployees')
 
   map from('address/billing/line1'), to('BillingStreet')

--- a/spec/models/entities/organization_spec.rb
+++ b/spec/models/entities/organization_spec.rb
@@ -108,7 +108,6 @@ describe Entities::Organization do
           :id=>[{:id=>"0012800000CaxiOAAR", :provider=>organization.oauth_provider, :realm=>organization.oauth_uid}],
           :name=>"Burlington Textiles Corp of America",
           :industry=>"Apparel",
-          :annual_revenue=>350000000.0,
           :number_of_employees=>9000,
           :address=>
           {
@@ -184,7 +183,6 @@ describe Entities::Organization do
         {
           :Name=>"GenePoint",
           :Industry=>"Biotechnology",
-          :AnnualRevenue=>30000000.0,
           :NumberOfEmployees=>265,
           :BillingStreet=>"345 Shoreline Park\nMountain View, CA 94043\nUSA",
           :BillingCity=>"Mountain View",


### PR DESCRIPTION
The field dos not seem to be enabled by default:
```
tenant="maestrano-uat", message="Error while pushing to SalesForce: INVALID_FIELD: No such column 'AnnualRevenue' on sobject of type Account"
```