### PR TITLE
Do not create parent organization with leads

### DIFF
--- a/app/models/entities/sub_entities/lead.rb
+++ b/app/models/entities/sub_entities/lead.rb
@@ -15,6 +15,6 @@ class Entities::SubEntities::Lead < Maestrano::Connector::Rails::SubEntityBase
   end
 
   def self.object_name_from_external_entity_hash(entity)
-    "#{entity['FirstName']} #{entity['LastName']}"
+    [entity['Salutation'], entity['FirstName'], entity['LastName']].compact.join(' ')
   end
 end

--- a/app/models/entities/sub_entities/lead_mapper.rb
+++ b/app/models/entities/sub_entities/lead_mapper.rb
@@ -13,7 +13,6 @@ class Entities::SubEntities::LeadMapper
     output[:is_lead] = true
     output[:is_customer] = false
     output[:lead_status] = input[:Status]
-    output[:opts] = { attach_to_organization: input['Company']} unless input['Company'].blank?
     output
   end
 
@@ -21,6 +20,7 @@ class Entities::SubEntities::LeadMapper
   map from('first_name'), to('FirstName')
   map from('last_name'), to('LastName'), default: 'Undefined'
   map from('job_title'), to('Title')
+  map from('company_name'), to('Company')
 
   map from('address_work/billing/line1'), to('Street')
   map from('address_work/billing/city'), to('City')

--- a/spec/models/entities/sub_entities/lead_spec.rb
+++ b/spec/models/entities/sub_entities/lead_spec.rb
@@ -97,9 +97,6 @@ describe Entities::SubEntities::Lead do
 
       let(:output_hash) {
         {
-          :opts => {
-            :attach_to_organization => "Jackson Controls"
-          },
           :id => [{"id"=>"00Q28000003FcanEAC", "provider"=>organization.oauth_provider, "realm"=>organization.oauth_uid}],
           :title=>"Mr",
           :first_name=>"Jeff",
@@ -107,6 +104,7 @@ describe Entities::SubEntities::Lead do
           :is_lead=>true,
           :is_customer=>false,
           :job_title=>"SVP, Procurement",
+          :company_name=>"Jackson Controls",
           :address_work=>
           {
             :billing=>{:country=>"Taiwan, Republic Of China"}


### PR DESCRIPTION
We should expose the Lead company name rather than creating an Organziation record. This avoids creating 2 contacts when using another application on the other end (which then comes back and creates the Account back into Salesforce)